### PR TITLE
delete hardcoded 'cluster.local' from svc path

### DIFF
--- a/stable/prometheus-nats-exporter/templates/deployment.yaml
+++ b/stable/prometheus-nats-exporter/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             {{- if .Values.config.metrics.subz }}
             - "-subz"
             {{- end }}
-            - "http://{{ .Values.config.nats.service }}.{{ .Values.config.nats.namespace }}.svc.cluster.local:{{ .Values.config.nats.port }}"
+            - "http://{{ .Values.config.nats.service }}.{{ .Values.config.nats.namespace }}.svc:{{ .Values.config.nats.port }}"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:


### PR DESCRIPTION
#### What this PR does / why we need it:
it is impossible to resolve the path to nats svc when the cluster has its own domain
(another way is to move cluster name into values

#### Special notes for your reviewer:
little fix (I hope you forgive me for i not following guidelines)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
